### PR TITLE
Initial commit for dev branch 'wire_spacing_fix'

### DIFF
--- a/bag/layout/tech.py
+++ b/bag/layout/tech.py
@@ -242,7 +242,9 @@ class TechInfoConfig(TechInfo, metaclass=abc.ABCMeta):
         res = self.config['resolution']
         if not unit_mode:
             width = int(round(width / res))
-
+        # I believe this one we need to change to account also for wiring length
+        # The spacing is calculated on lines 214-226 (_space_helper() function)
+        # TODO: Implement changes to reflect wire length also
         ans = self.get_min_space_unit(layer_type, width, same_color=same_color)
 
         if unit_mode:


### PR DESCRIPTION
Let's fix the wire spacing issue in a general manner. Problem: The wire spacing can be a function of not only width but of length as well. Solution: Make changes to bag/layout/tech.py to reflect also the length property when calculating the wire spacing.